### PR TITLE
젠킨스용 clusterrolebinding 등록 부분 삭제

### DIFF
--- a/hands-on/valve-devops-quickstart.md
+++ b/hands-on/valve-devops-quickstart.md
@@ -224,17 +224,6 @@ Jenkins -> Manage Jenkins -> Configure System -> Kubernetes URL에 443포트로 
 https://kubernetes.default:443
 ```
 
-#### EKS 클러스트 롤 바인딩
-
-valve-tools 설치된 폴더로 이동해서 다음 명령어 실행합니다.
-
-```bash
-cd valve-tools/templates/jenkins
-kubectl apply -f jenkins-rollbinding.yaml
-kubectl get clusterrolebinding    # 롤 바인딩 정보 조회, valve:jenkins 정보 있는지 확인한다.
-kubectl get clusterrolebinding valve:jenkins -o yaml      # 상세 정보 조회
-```
-
 ### sample 프로젝트 배포
 
 #### Multibranch Pipeline 생성


### PR DESCRIPTION
valve-tools 로 jenkins 설치하면 clusterrolebinding 등록 하도록 기능 추가함.
수작업으로 등록할 필요 없음.